### PR TITLE
Add info about security-bundle in the README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,3 +50,7 @@ logs in the profiler.
 If you are using ``VarDumperServiceProvider``, add ``symfony/debug-bundle`` as
 a Composer dependency to display VarDumper dumps in the toolbar and the
 profiler.
+
+If you are using ``symfony/security``, add ``symfony/security-bundle`` as
+a Composer dependency to display Security related information in the toolbar
+and the profiler.


### PR DESCRIPTION
Along the lines of monolog-bridge and debug-bundle, the security-bundle is needed as a dependency to show security information panel in the toolbar. This change is to document that.

This should close #96.

Also this should be improved once #90 is resolved.